### PR TITLE
Fixed Url issue in template file

### DIFF
--- a/WGBS_report_template.txt
+++ b/WGBS_report_template.txt
@@ -9,7 +9,7 @@ SEQUENCING_NOTE: https://confluence.ris.wustl.edu/pages/viewpage.action?spaceKey
 
 Link to the model group:
 
-https://spectacle.gsc.wustl.edu/model_groups/model_group_id/${MODEL_GROUP_ID}
+https://spectacle.gsc.wustl.edu/model_groups/${MODEL_GROUP_ID}
 
 Attachment:
 Attached is the information pertaining to the builds.


### PR DESCRIPTION
Removed "model_group_id" from url in template file.